### PR TITLE
Fix Model dataclass

### DIFF
--- a/google/generativeai/types/model_types.py
+++ b/google/generativeai/types/model_types.py
@@ -117,6 +117,7 @@ class Model:
     output_token_limit: int
     supported_generation_methods: list[str]
     temperature: float | None = None
+    max_temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -44,7 +44,7 @@ class UnitTests(parameterized.TestCase):
 
         client._client_manager.clients["model"] = self.client
 
-        # TODO(markdaoust): Check if typechecking works better if wee define this as a
+        # TODO(markdaoust): Check if typechecking works better if we define this as a
         #                   subclass of `glm.ModelServiceClient`, would pyi files for `glm`. help?
         def add_client_method(f):
             name = f.__name__
@@ -159,6 +159,15 @@ class UnitTests(parameterized.TestCase):
             self.assertIsInstance(model, model_types.Model)
         else:
             self.assertIsInstance(model, model_types.TunedModel)
+
+    def test_max_temperature(self):
+        name = "models/fake-bison-001"
+        max_temperature = 3.0
+        self.responses = {
+            "get_model": protos.Model(name=name, max_temperature=max_temperature),
+        }
+        model = models.get_model(name)
+        self.assertEqual(max_temperature, model.max_temperature)
 
     @parameterized.named_parameters(
         ["simple", "mystery-bison-001"],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -166,7 +166,7 @@ class UnitTests(parameterized.TestCase):
         self.responses = {
             "get_model": protos.Model(name=name, max_temperature=max_temperature),
         }
-        model = models.get_model(name)
+        model = models.get_base_model(name)
         self.assertEqual(max_temperature, model.max_temperature)
 
     @parameterized.named_parameters(


### PR DESCRIPTION
Dataclass Model misses max_temperature field which brakes list_models()

## Description of the change
Add field max_temperature to Model dataclass

## Motivation
This change fixes list_models()

## Type of change
Choose one: (Bug fix | Feature request | Documentation | Other)

## Checklist
- [+ ] I have performed a self-review of my code.
- [+ ] I have added detailed comments to my code where applicable.
- [ +] I have verified that my change does not break existing code.
- [ +] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ +] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ +] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
